### PR TITLE
"Save File" and "Save File as"

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -45,7 +45,8 @@ AssDeb has 6 zones.
 The File menu in the bar on the top of the window lets you:
 - Open a file, in which case its content will show in the text area. 
 - Close the file. This will clear the text area and reset the auto-save pat.
-- Save a file, in which case the content of the text area can be written to a file.
+- Save a file, which will update the file previously opened with the content in the text area.
+- Save a file as, in which case the content of the text area can be written to a specified file.
 - Select a language, which is a WIP feature to support more than ArmV4. (Armv5 is not functional yet.)
 
 > [!NOTE]  

--- a/js/render_logic/electron_inter.js
+++ b/js/render_logic/electron_inter.js
@@ -10,10 +10,26 @@ const Armv5 = require('./js/render_logic/armv5/armv5.js');
 const { log } = require('console');
 const fsPromises = require('fs').promises;
 
+var first_file = true;
 var can_gen_hex = true;
 
 //Listen to event "Open file" from main.js
 ipcRenderer.on('Open file', (event, arg) => {
+	if (first_file == false) {
+
+        const userResponse = confirm("Do you want to save your file before opening another one?");
+
+        if (userResponse) {
+            // User clicked "OK" and wants to save it
+
+            fs.writeFile (opened_file, text_area.value, function(err) {
+                if (err) throw err;
+            });
+        }
+    }
+
+    first_file = false;
+	
     //Open file dialog
     dialog.showOpenDialog({
             properties: ['openFile']
@@ -91,6 +107,12 @@ ipcRenderer.on('Close file', (event, arg) => {
 })
 
 ipcRenderer.on('Save file', (event, arg) => {
+    fs.writeFile (opened_file, text_area.value, function(err) {
+        if (err) throw err;
+    });
+})
+
+ipcRenderer.on('Save file as', (event, arg) => {
     dialog.showSaveDialog().then((path) => {
         opened_file = path.filePath;
         fs.writeFile (path.filePath, text_area.value, function(err) {


### PR DESCRIPTION
I changed the "Save File" functionality to subscribe automatically the file that was opened. At the same time, I added a "Save File as" function that does exactly what the previous function did. Implemented a dialog box asking if user wants to 'Save File' before opening another file. Only asks this if it's not the first file opened.